### PR TITLE
Use json-cycle to allow for circular references in json

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 'use strict'
 var path = require('path')
 var fs = require('fs')
+var stringify = require('json-cycle').stringify
 
 //
 var JSONReporter = function (baseReporterDecorator, config, helper, logger) {
@@ -33,7 +34,7 @@ var JSONReporter = function (baseReporterDecorator, config, helper, logger) {
 
   this.onRunComplete = function (browser, result) {
     history.summary = result
-    var json = JSON.stringify(history, undefined, '\t')
+    var json = stringify(history, undefined, '\t')
 
     if (stdout) {
       process.stdout.write(json)

--- a/package.json
+++ b/package.json
@@ -12,21 +12,28 @@
     "type": "git",
     "url": "git://github.com/douglasduteil/karma-json-reporter.git"
   },
-  "keywords": ["karma-plugin", "reporter", "json"],
+  "keywords": [
+    "karma-plugin",
+    "reporter",
+    "json"
+  ],
   "peerDependencies": {
     "karma": ">=0.9"
   },
+  "dependencies": {
+    "json-cycle": "^1.3.0"
+  },
   "devDependencies": {
     "chai": "^4.1.2",
+    "eslint": "^4.7.2",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "eslint": "^4.7.2",
+    "karma": ">=0.9",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
-    "karma": ">=0.9",
     "mocha": "^3.5.3"
   },
   "author": "Douglas Duteil",


### PR DESCRIPTION
We ran into an issue where the reporter was attempting to stringify an object which contained circular references. Because `JSON.parse` does not support circular references natively, this would inevitably crash our test run. This commit changes the reporter to user `json-cycle`'s `stringify` method instead.